### PR TITLE
PMM-4010 Updated travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,15 @@ services:
 
 go:
   - 1.12.x
+  - 1.13.x
   - master
+
+# skip non-trunk PMM-XXXX branch builds, but still build pull requests
+branches:
+  except:
+    - /^PMM\-\d{4}/
+
+go_import_path: github.com/percona/proxysql_exporter
 
 cache:
   directories:


### PR DESCRIPTION
- Added Go 1.13.x
- Added go_import_path
- Made it skip non-trunk PMM-XXXX branch builds, but still build pull requests.