### PR TITLE
PMM-9840 log level like in another exporters as part of issue PMM-7326

### DIFF
--- a/proxysql_exporter.go
+++ b/proxysql_exporter.go
@@ -44,6 +44,8 @@ var (
 	mysqlCommandCounter          = flag.Bool("collect.stats_command_counter", false, "Collect histograms over command latency")
 	mysqlRuntimeServers          = flag.Bool("collect.runtime_mysql_servers", false, "Collect from runtime_mysql_servers.")
 	memoryMetricsF               = flag.Bool("collect.stats_memory_metrics", false, "Collect memory metrics from stats_memory_metrics.")
+
+	logLevel = flag.String("log.level", "", "Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]")
 )
 
 func main() {
@@ -60,6 +62,15 @@ func main() {
 	if *versionF {
 		fmt.Println(version.Print(program))
 		os.Exit(0)
+	}
+
+	if *logLevel != "" {
+		err := log.Base().SetLevel(*logLevel)
+
+		if err != nil {
+			log.Errorf("error: not a valid logrus Level: %q, try --help", *logLevel)
+			os.Exit(0)
+		}
 	}
 
 	dsn := os.Getenv("DATA_SOURCE_NAME")


### PR DESCRIPTION
[PMM-9840](https://jira.percona.com/browse/PMM-9840) as part of issue [PMM-7326](https://jira.percona.com/browse/PMM-7326)

Build: [SUBMODULES-2443](https://github.com/Percona-Lab/pmm-submodules/pull/2443)

Did simple local test with:
```bash
./proxysql_exporter --log.level=info
./proxysql_exporter --log.level=error
./proxysql_exporter --log.level=undefined_log_level_expect_error_message
```

- [ ] https://github.com/percona/mysqld_exporter/pull/93
- [ ] https://github.com/percona/azure_metrics_exporter/pull/4