### PR TITLE
PMM-10525: Add proxysql_info metric which contain proxysql version

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -215,7 +215,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 		}
 	}
 
-	if err = scrapeProxySqlInfo(db, ch); err != nil {
+	if err = scrapeProxySQLInfo(db, ch); err != nil {
 		log.Errorln("Error scraping for collect.proxysql_info", err)
 		e.scrapeErrorsTotal.WithLabelValues("collect.proxysql_info").Inc()
 	}
@@ -775,10 +775,10 @@ func scrapeMemoryMetrics(db *sql.DB, ch chan<- prometheus.Metric) error {
 	return rows.Err()
 }
 
-const proxysqlVersionQuery = "select variable_value from global_variables where variable_name = 'admin-version'"
+const proxySQLVersionQuery = "select variable_value from global_variables where variable_name = 'admin-version'"
 
-func scrapeProxySqlInfo(db *sql.DB, ch chan<- prometheus.Metric) error {
-	rows, err := db.Query(proxysqlVersionQuery)
+func scrapeProxySQLInfo(db *sql.DB, ch chan<- prometheus.Metric) error {
+	rows, err := db.Query(proxySQLVersionQuery)
 	if err != nil {
 		return err
 	}

--- a/exporter.go
+++ b/exporter.go
@@ -214,6 +214,11 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 			e.scrapeErrorsTotal.WithLabelValues("collect.stats_command_counter_metrics").Inc()
 		}
 	}
+
+	if err = scrapeProxySqlInfo(db, ch); err != nil {
+		log.Errorln("Error scraping for collect.proxysql_info", err)
+		e.scrapeErrorsTotal.WithLabelValues("collect.proxysql_info").Inc()
+	}
 }
 
 // metric contains information about Prometheus metric.
@@ -767,6 +772,36 @@ func scrapeMemoryMetrics(db *sql.DB, ch chan<- prometheus.Metric) error {
 		)
 	}
 
+	return rows.Err()
+}
+
+const proxysqlVersionQuery = "select variable_value from global_variables where variable_name = 'admin-version'"
+
+func scrapeProxySqlInfo(db *sql.DB, ch chan<- prometheus.Metric) error {
+	rows, err := db.Query(proxysqlVersionQuery)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var version string
+
+		err := rows.Scan(&version)
+		if err != nil {
+			return err
+		}
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, "", "info"),
+				"ProxySQL version",
+				[]string{"version"}, nil,
+			),
+			prometheus.GaugeValue,
+			0,
+			version,
+		)
+	}
 	return rows.Err()
 }
 

--- a/exporter.go
+++ b/exporter.go
@@ -794,7 +794,7 @@ func scrapeProxySQLInfo(db *sql.DB, ch chan<- prometheus.Metric) error {
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(
 				prometheus.BuildFQName(namespace, "", "info"),
-				"ProxySQL version",
+				"ProxySQL info",
 				[]string{"version"}, nil,
 			),
 			prometheus.GaugeValue,


### PR DESCRIPTION
PMM-10525: Add new metric to get proxysql version.

This version we want to have to fetch it for Telemetry functionality. This version contains in the global_variables table, which is described in this documentation https://proxysql.com/Documentation/global-variables/admin-variables/#admin-version.

FB: https://github.com/Percona-Lab/pmm-submodules/pull/2718