### PR TITLE
PMM-11312 --version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ promu:
 		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(subst aarch64,arm64,$(shell uname -m)))) \
 		$(GO) build -modfile=go.mod -o bin/promu github.com/prometheus/promu
 
-feature-build:
+release:
 	go build -ldflags="$(GO_BUILD_LDFLAGS)" -o $(PMM_RELEASE_PATH)/proxysql_exporter
 
 .PHONY: all style format build test vet tarball docker promu

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ DOCKER_IMAGE_TAG    ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 # Race detector is only supported on amd64.
 RACE := $(shell test $$(go env GOARCH) != "amd64" || (echo "-race"))
 
+GO_BUILD_LDFLAGS = -X github.com/prometheus/common/version.Version=$(shell cat VERSION) -X github.com/prometheus/common/version.Revision=$(shell git rev-parse HEAD) -X github.com/prometheus/common/version.Branch=$(shell git describe --always --contains --all) -X github.com/prometheus/common/version.BuildUser= -X github.com/prometheus/common/version.BuildDate=$(shell date +%FT%T%z) -s -w
+
+export PMM_RELEASE_PATH?=.
+
 all: format build test
 
 style:
@@ -64,5 +68,7 @@ promu:
 		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(subst aarch64,arm64,$(shell uname -m)))) \
 		$(GO) build -modfile=go.mod -o bin/promu github.com/prometheus/promu
 
+feature-build:
+	go build -ldflags="$(GO_BUILD_LDFLAGS)" -o $(PMM_RELEASE_PATH)/proxysql_exporter
 
 .PHONY: all style format build test vet tarball docker promu


### PR DESCRIPTION
[PMM-11312](https://jira.percona.com/browse/PMM-11312)

Build: [SUBMODULES-3002](https://github.com/Percona-Lab/pmm-submodules/pull/3002)

- [ ] https://github.com/percona/pmm/pull/1551
- [ ] https://github.com/percona/node_exporter/pull/42
- [ ] https://github.com/percona/mysqld_exporter/pull/112
- [ ] https://github.com/percona/postgres_exporter/pull/92
- [ ] https://github.com/percona/proxysql_exporter/pull/64
- [ ] https://github.com/percona/rds_exporter/pull/84
- [ ] https://github.com/percona/azure_metrics_exporter/pull/8